### PR TITLE
Package/py pysam macos

### DIFF
--- a/var/spack/repos/builtin/packages/py-pysam/package.py
+++ b/var/spack/repos/builtin/packages/py-pysam/package.py
@@ -22,15 +22,20 @@ class PyPysam(PythonPackage):
     version("0.7.7", sha256="c9f3018482eec99ee199dda3fdef2aa7424dde6574672a4c0d209a10985755cc")
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-cython@0.29.12:", when="@0.18:", type="build")
-    depends_on("py-cython@0.21:", when="@0.14:", type="build")
+    depends_on("py-cython@0.29.12:", type="build", when="@0.18:")
+    depends_on("py-cython@0.21:", type="build", when="@0.14:")
     depends_on("py-cython@0.17:", type="build")
     depends_on("curl")
     depends_on("bcftools")
+    depends_on("htslib@:1.6", when="@:0.13")
     depends_on("htslib")
     depends_on("samtools")
 
-    depends_on("htslib@:1.6", when="@:0.13")
-
     def setup_build_environment(self, env):
         env.set("LDFLAGS", self.spec["curl"].libs.search_flags)
+        # linking htslib, see:
+        # http://pysam.readthedocs.org/en/latest/installation.html#external
+        # https://github.com/pysam-developers/pysam/blob/v0.9.0/setup.py#L79
+        env.set("HTSLIB_MODE", "external")
+        env.set("HTSLIB_LIBRARY_DIR", self.spec["htslib"].prefix.lib)
+        env.set("HTSLIB_INCLUDE_DIR", self.spec["htslib"].prefix.include)

--- a/var/spack/repos/builtin/packages/py-pysam/package.py
+++ b/var/spack/repos/builtin/packages/py-pysam/package.py
@@ -22,8 +22,8 @@ class PyPysam(PythonPackage):
     version("0.7.7", sha256="c9f3018482eec99ee199dda3fdef2aa7424dde6574672a4c0d209a10985755cc")
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-cython@0.29.12:", type="build", when="@0.18:")
-    depends_on("py-cython@0.21:", type="build", when="@0.14:")
+    depends_on("py-cython@0.29.12:", when="@0.18:", type="build")
+    depends_on("py-cython@0.21:", when="@0.14:", type="build")
     depends_on("py-cython@0.17:", type="build")
     depends_on("curl")
     depends_on("xz")

--- a/var/spack/repos/builtin/packages/py-pysam/package.py
+++ b/var/spack/repos/builtin/packages/py-pysam/package.py
@@ -26,16 +26,9 @@ class PyPysam(PythonPackage):
     depends_on("py-cython@0.21:", type="build", when="@0.14:")
     depends_on("py-cython@0.17:", type="build")
     depends_on("curl")
-    depends_on("bcftools")
-    depends_on("htslib@:1.6", when="@:0.13")
-    depends_on("htslib")
-    depends_on("samtools")
+    depends_on("xz")
 
     def setup_build_environment(self, env):
         env.set("LDFLAGS", self.spec["curl"].libs.search_flags)
-        # linking htslib, see:
-        # http://pysam.readthedocs.org/en/latest/installation.html#external
-        # https://github.com/pysam-developers/pysam/blob/v0.9.0/setup.py#L79
-        env.set("HTSLIB_MODE", "external")
-        env.set("HTSLIB_LIBRARY_DIR", self.spec["htslib"].prefix.lib)
-        env.set("HTSLIB_INCLUDE_DIR", self.spec["htslib"].prefix.include)
+        if self.spec.platform == "darwin":
+            env.remove_flags("LDSHARED", "-bundle")


### PR DESCRIPTION
Fixed a bug that was preventing `py-pysam` from building on MacOS (`clang: error: invalid argument '-bundle' not allowed with '-dynamiclib'`), and cleaned up the package in general. Previously, the `package.py` included `bcftools`/`htslib`/`samtools` deps, but `pysam` actually bundles all those necessary libs for building in the tarball, and they are used by default. I removed those dependencies entirely since the package wasn't using them anyway. This [mirrors the changes in the bioconda recipe](https://github.com/bioconda/bioconda-recipes/pull/13093).

I also tested with external (spack-installed) `htslib` - which built fine - but thought that it would be easier to just use the included libs instead of making sure the spack deps match the bundled libs for every release. See https://pysam.readthedocs.io/en/latest/installation.html#external for more detail

